### PR TITLE
fix some warnings, show more warnings

### DIFF
--- a/arm7/Makefile
+++ b/arm7/Makefile
@@ -27,7 +27,8 @@ ARCH	:=	-mthumb-interwork -marm
 CFLAGS	:=	-g -Wall -O3\
 		-mcpu=arm7tdmi -mtune=arm7tdmi -fomit-frame-pointer\
 		-ffast-math \
-		$(ARCH)
+		$(ARCH) \
+		 -pedantic -Wall -Wextra -Wabi -Wcast-qual -Wfloat-equal -Wmissing-declarations -Wmissing-format-attribute -Wpacked -Wredundant-decls -Wshadow
 
 CFLAGS	+=	$(INCLUDE) -DARM7
 CXXFLAGS	:=	$(CFLAGS) -fno-exceptions -fno-rtti

--- a/arm7/source/main.cpp
+++ b/arm7/source/main.cpp
@@ -264,7 +264,7 @@ int main()
 			}
 		}
 #else
-		while(*((vu32*)0x04000184) & (1 << 8));
+		while(*((vu32*)0x04000184) & (1 << 8))
 		{
 			if(!(*((vu32*)0x04000136) & 1))
 				gba_sound_resync();

--- a/arm9/Makefile
+++ b/arm9/Makefile
@@ -25,10 +25,11 @@ DATA		:=	data
 #---------------------------------------------------------------------------------
 ARCH	:=	-marm -mthumb-interwork#-mthumb
 
-CFLAGS	:=	-g -Wall -O2 -nostdlib -nodefaultlibs \
+CFLAGS	:=	-g -O2 -nostdlib -nodefaultlibs \
  			-march=armv5te -mtune=arm946e-s -fno-unwind-tables -fno-asynchronous-unwind-tables -fno-tree-loop-distribute-patterns -fno-builtin -fomit-frame-pointer\
 			-ffast-math \
-			$(ARCH) 
+			$(ARCH)  \
+		 -pedantic -Wall -Wextra -Wabi -Wcast-qual -Wfloat-equal -Wmissing-declarations -Wmissing-format-attribute -Wpacked -Wredundant-decls -Wshadow
 
 CFLAGS	+=	$(INCLUDE) -DARM9
 CXXFLAGS	:=	$(CFLAGS) -fno-rtti -fno-exceptions -fnon-call-exceptions

--- a/arm9/source/sd_access.cpp
+++ b/arm9/source/sd_access.cpp
@@ -895,7 +895,7 @@ extern "C" ITCM_CODE void read_gba_rom(uint32_t address, uint32_t size, uint8_t*
 	//uint16_t* pSrc = (uint16_t*)((uint8_t*)cluster_data + cluster_offset);
 	arm9_memcpy16((uint16_t*)dst, (uint16_t*)((uint8_t*)cluster_data + cluster_offset), left_in_this_cluster / 2);
 	size_left -= left_in_this_cluster;
-	if(size_left <= 0) return;
+	if(size_left = 0) return;
 	dst += left_in_this_cluster;
 	cluster++;
 	//read whole clusters
@@ -906,7 +906,7 @@ extern "C" ITCM_CODE void read_gba_rom(uint32_t address, uint32_t size, uint8_t*
 		size_left -= 1 << vram_cd->sd_info.cluster_shift;
 		dst += 1 << vram_cd->sd_info.cluster_shift;
 	}
-	if(size_left <= 0) return;
+	if(size_left = 0) return;
 	//read data that's left
 	cluster_data = get_cluster_data(cluster);
 	arm9_memcpy16((uint16_t*)dst, (uint16_t*)cluster_data, size_left / 2);

--- a/arm9/source/sd_access.cpp
+++ b/arm9/source/sd_access.cpp
@@ -895,7 +895,7 @@ extern "C" ITCM_CODE void read_gba_rom(uint32_t address, uint32_t size, uint8_t*
 	//uint16_t* pSrc = (uint16_t*)((uint8_t*)cluster_data + cluster_offset);
 	arm9_memcpy16((uint16_t*)dst, (uint16_t*)((uint8_t*)cluster_data + cluster_offset), left_in_this_cluster / 2);
 	size_left -= left_in_this_cluster;
-	if(size_left = 0) return;
+	if(size_left == 0) return;
 	dst += left_in_this_cluster;
 	cluster++;
 	//read whole clusters
@@ -906,7 +906,7 @@ extern "C" ITCM_CODE void read_gba_rom(uint32_t address, uint32_t size, uint8_t*
 		size_left -= 1 << vram_cd->sd_info.cluster_shift;
 		dst += 1 << vram_cd->sd_info.cluster_shift;
 	}
-	if(size_left = 0) return;
+	if(size_left == 0) return;
 	//read data that's left
 	cluster_data = get_cluster_data(cluster);
 	arm9_memcpy16((uint16_t*)dst, (uint16_t*)cluster_data, size_left / 2);


### PR DESCRIPTION
I ran cppcheck 1.77 on the sourcecode
https://github.com/danmar/cppcheck/releases

Most of the warnings are beyond my level of expertise to fix
Those i could handle i fixed

I also added all the warnings recomended to be enabled in gcc by cppcheck devs.

Its up to you to decide if you want to do anything about the warnings that are coming from libnds, but if you do please send PR's for them to https://github.com/devkitPro/libnds