### PR TITLE
RTC for FatFs filetimes. Saves subdir support.

### DIFF
--- a/arm9/source/fat/ff.h
+++ b/arm9/source/fat/ff.h
@@ -302,6 +302,7 @@ FRESULT f_rename (const TCHAR* path_old, const TCHAR* path_new);	/* Rename/Move 
 FRESULT f_stat (const TCHAR* path, FILINFO* fno);					/* Get file status */
 FRESULT f_chmod (const TCHAR* path, BYTE attr, BYTE mask);			/* Change attribute of a file/dir */
 FRESULT f_utime (const TCHAR* path, const FILINFO* fno);			/* Change timestamp of a file/dir */
+FRESULT f_touch (const TCHAR* path);								/* Set timestamp of a file/dir to current time */
 FRESULT f_chdir (const TCHAR* path);								/* Change current directory */
 FRESULT f_chdrive (const TCHAR* path);								/* Change current drive */
 FRESULT f_getcwd (TCHAR* buff, UINT len);							/* Get current directory */

--- a/arm9/source/fat/ffconf.h
+++ b/arm9/source/fat/ffconf.h
@@ -236,7 +236,7 @@
 /  Note that enabling exFAT discards ANSI C (C89) compatibility. */
 
 
-#define FF_FS_NORTC		1
+#define FF_FS_NORTC		0
 #define FF_NORTC_MON	1
 #define FF_NORTC_MDAY	1
 #define FF_NORTC_YEAR	2018

--- a/arm9/source/gbaBoot.vram.cpp
+++ b/arm9/source/gbaBoot.vram.cpp
@@ -146,6 +146,9 @@ static RomLoadResult createLoadSave(const char* path, const save_type_t* saveTyp
 			return ROM_LOAD_RESULT_SAVE_CREATE_ERR;
 #endif
 	}
+#ifndef ISNITRODEBUG
+	else f_touch(path);
+#endif
 
 	if (saveType && (saveType->type & SAVE_TYPE_TYPE_MASK) == SAVE_TYPE_EEPROM && vram_cd->fil.obj.objsize == 512)
 		vram_cd->save_work.saveSize = 512;

--- a/arm9/source/gbaBoot.vram.cpp
+++ b/arm9/source/gbaBoot.vram.cpp
@@ -214,6 +214,14 @@ RomLoadResult gbab_loadRom(const char* path)
     u32 gameCode = *(u32*)(MAIN_MEMORY_ADDRESS_ROM_DATA + 0xAC);
     gbab_loadFrame(gameCode);
 
+    if (gEmuSettingUseSavesDir)
+		if (f_chdir("saves") != FR_OK) {
+			if (f_mkdir("saves") != FR_OK)
+				return ROM_LOAD_RESULT_SAVE_CREATE_ERR;
+			if (f_chdir("saves") != FR_OK)
+				return ROM_LOAD_RESULT_SAVE_CREATE_ERR;
+		}
+
     char nameBuf[256];
 	for (int i = 0; i < 256; i++)
 	{
@@ -229,5 +237,9 @@ RomLoadResult gbab_loadRom(const char* path)
 	long_name_ptr[3] = 'v';
 	long_name_ptr[4] = '\0';
 
-    return createLoadSave(nameBuf, saveType);
+    RomLoadResult result = createLoadSave(nameBuf, saveType);
+
+    if (gEmuSettingUseSavesDir) f_chdir("..");
+
+    return result;
 }

--- a/arm9/source/gui/SettingsScreen.vram.cpp
+++ b/arm9/source/gui/SettingsScreen.vram.cpp
@@ -23,9 +23,10 @@
 static PUT_IN_VRAM settings_item_t sEmulationItems[] =
 {    
     //{ SETTINGS_ITEM_MODE_CHECK, "Enable autosaving", "Writes back the save to sd after a game saves", NULL, &gEmuSettingAutoSave },
-	{ SETTINGS_ITEM_MODE_CHECK, "Enable DS main memory i-cache", "Boosts speed, but causes timing bugs in a few games", NULL, &gEmuSettingMainMemICache },    
+	{ SETTINGS_ITEM_MODE_CHECK, "Enable DS main memory i-cache", "Boosts speed, but causes timing bugs in a few games", NULL, &gEmuSettingMainMemICache },
 	{ SETTINGS_ITEM_MODE_CHECK, "Enable wram i-cache", "Boosts speed, but some games may crash", NULL, &gEmuSettingWramICache },
-    { SETTINGS_ITEM_MODE_CHECK, "Skip bios intro", "Directly boot the game without playing the intro", NULL, &gEmuSettingSkipIntro }
+	{ SETTINGS_ITEM_MODE_CHECK, "Skip bios intro", "Directly boot the game without playing the intro", NULL, &gEmuSettingSkipIntro },
+	{ SETTINGS_ITEM_MODE_CHECK, "Use saves directory", "Store save files in saves subdirectory (like TWiLightMenu++)", NULL, &gEmuSettingUseSavesDir },
 };
 
 static PUT_IN_VRAM settings_item_t sDisplayItems[] =

--- a/arm9/source/settings.h
+++ b/arm9/source/settings.h
@@ -2,6 +2,7 @@
 
 extern u32 gEmuSettingUseBottomScreen;
 //extern u32 gEmuSettingAutoSave;
+extern u32 gEmuSettingUseSavesDir;
 extern u32 gEmuSettingCenterMask;
 extern u32 gEmuSettingFrame;
 extern u32 gEmuSettingMainMemICache;

--- a/arm9/source/settings.vram.cpp
+++ b/arm9/source/settings.vram.cpp
@@ -18,6 +18,9 @@ u32 gEmuSettingUseBottomScreen;
 static const char* sEmuSettingAutoSaveName = "autoSave";
 u32 gEmuSettingAutoSave;
 
+static const char* sEmuSettingUseSavesDir = "useSavesDir";
+u32 gEmuSettingUseSavesDir;
+
 static const char* sEmuSettingFrameName = "frame";
 u32 gEmuSettingFrame;
 
@@ -50,6 +53,7 @@ static void loadDefaultSettings()
 {
     gEmuSettingUseBottomScreen = false;
     gEmuSettingAutoSave = true;
+    gEmuSettingUseSavesDir = false;
     gEmuSettingFrame = true;
     gEmuSettingCenterMask = true;
     gEmuSettingMainMemICache = true;
@@ -93,6 +97,8 @@ static void iniPropertyCallback(void* arg, const char* section, const char* key,
             gEmuSettingUseBottomScreen = parseBoolean(value, false);
         else if(!strcmp(key, sEmuSettingAutoSaveName))
             gEmuSettingAutoSave = parseBoolean(value, true);
+        else if(!strcmp(key, sEmuSettingUseSavesDir))
+            gEmuSettingUseSavesDir = parseBoolean(value, false);
         else if(!strcmp(key, sEmuSettingFrameName))
             gEmuSettingFrame = parseBoolean(value, true);
         else if(!strcmp(key, sEmuSettingCenterMaskName))
@@ -140,6 +146,7 @@ bool settings_save()
     writer.WriteSection(sEmulationSectionName);
     writer.WriteBooleanProperty(sEmuSettingUseBottomScreenName, gEmuSettingUseBottomScreen);
     //writer.WriteBooleanProperty(sEmuSettingAutoSaveName, gEmuSettingAutoSave);
+    writer.WriteBooleanProperty(sEmuSettingUseSavesDir, gEmuSettingUseSavesDir);
     writer.WriteBooleanProperty(sEmuSettingFrameName, gEmuSettingFrame);
     writer.WriteBooleanProperty(sEmuSettingCenterMaskName, gEmuSettingCenterMask);
     writer.WriteBooleanProperty(sEmuSettingMainMemICacheName, gEmuSettingMainMemICache);


### PR DESCRIPTION
* Added RTC call (copied from GBARunner2's implementation) to ARM9 FatFs module. Update modification time of game save whenever game is launched. (Commits 7908e7d and 4a4543f)
* Added option to emulator settings menu to store game saves in a "./saves/" subdirectory of the ROM file's directory. Exactly like TWiLightMenu++. Off by default (of course). (Commits 0b23ba8 and e14d6e0)

Tested on DSi (DS-mode flashcard and TWiLightMenu++) and 3DS (TWiLightMenu++).

Please let me know if any of the code I've submitted is not clear or if you find any bugs when testing it.

Thanks for your consideration!