### PR TITLE
Can't build on Linux because makefile has .exe in it

### DIFF
--- a/arm9/Makefile
+++ b/arm9/Makefile
@@ -168,28 +168,28 @@ $(ARM9ELF)	:	$(OFILES)
 #---------------------------------------------------------------------------------
 	@echo $(notdir $<)
 	@$(bin2o)
-	arm-none-eabi-objcopy.exe --rename-section .rodata=.vram $(@)
+	arm-none-eabi-objcopy --rename-section .rodata=.vram $(@)
 
 #---------------------------------------------------------------------------------
 %.nbfc.o	:	%.nbfc
 #---------------------------------------------------------------------------------
 	@echo $(notdir $<)
 	@$(bin2o)
-	arm-none-eabi-objcopy.exe --rename-section .rodata=.vram $(@)
+	arm-none-eabi-objcopy --rename-section .rodata=.vram $(@)
 
 #---------------------------------------------------------------------------------
 %.nbfs.o	:	%.nbfs
 #---------------------------------------------------------------------------------
 	@echo $(notdir $<)
 	@$(bin2o)
-	arm-none-eabi-objcopy.exe --rename-section .rodata=.vram $(@)
+	arm-none-eabi-objcopy --rename-section .rodata=.vram $(@)
 
 #---------------------------------------------------------------------------------
 %.nbfp.o	:	%.nbfp
 #---------------------------------------------------------------------------------
 	@echo $(notdir $<)
 	@$(bin2o)
-	arm-none-eabi-objcopy.exe --rename-section .rodata=.vram $(@)
+	arm-none-eabi-objcopy --rename-section .rodata=.vram $(@)
 
 -include $(DEPSDIR)/*.d
  


### PR DESCRIPTION
The arm9 makefile tries to run `arm-none-eabi-objcopy.exe`. 

Not a problem on Windows, but it's 100 percent going to fail anywhere else.

This small change made it build on Linux (in my case, Ubuntu 20.04 on WSL2), and it runs as expected. 